### PR TITLE
Fix issue with keyboard at startup

### DIFF
--- a/ps2/ps2.c
+++ b/ps2/ps2.c
@@ -88,6 +88,7 @@ void PS2_setup()
     irq_register(1, (irq_handler_t)PS2_kdb_handler, NULL);
     irq_register(12, (irq_handler_t)PS2_mouse_handler, NULL);
     PS2_mouse_setup();
+    PS2_kdb_setup();
 
     kdb_ino = vfs_inode(1, FL_CHR, NULL);
     kdb_ino->dev->block = sizeof(event_t);

--- a/ps2/ps2.h
+++ b/ps2/ps2.h
@@ -32,6 +32,7 @@ extern inode_t *kdb_ino;
 void PS2_event(inode_t *ino, uint8_t type, int32_t param1, int32_t param2);
 
 void PS2_kdb_handler();
+void PS2_kdb_setup();
 
 void PS2_mouse_handler();
 void PS2_mouse_setup();

--- a/ps2/ps2_kdb.c
+++ b/ps2/ps2_kdb.c
@@ -42,7 +42,14 @@ static void PS2_kbd_led(uint8_t status)
     outb(0x60, status & 7);
 }
 
+void PS2_kdb_setup()
+{
+    while ((inb(0x64) & 0x01)) {
+        inb(0x60);
+    }
 
+    outb(0x64, 0xAE);
+}
 
 
 void PS2_kdb_handler()
@@ -50,9 +57,9 @@ void PS2_kdb_handler()
     evmsg_t msg;
     pipe_t *kdb_buffer = (pipe_t *)kdb_ino->info;
     char c = 0;
-    for (;;) {
-        if (inb(0x60) != c)
-            break;
+
+    if (!(inb(0x64) & 0x01)) {
+        return;
     }
 
     c = inb(0x60);


### PR DESCRIPTION
This change attempts to fix the issue with a key down event whenever krish starts.